### PR TITLE
Revert "build faudio dependency for wine"

### DIFF
--- a/com.fightcade.Fightcade.Wine.yml
+++ b/com.fightcade.Fightcade.Wine.yml
@@ -36,46 +36,11 @@ cleanup:
 
 
 modules:
-  - name: faudio32
-    buildsystem: cmake-ninja
-    build-options:
-      prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
-      prefix: /app/wine
-      ldflags: -L/app/lib32
-      prepend-path: /usr/lib/sdk/toolchain-i386/bin
-      env:
-        CC: i686-unknown-linux-gnu-gcc
-        CXX: i686-unknown-linux-gnu-g++
-      libdir: /app/wine/lib32
-      strip: true
-      no-debuginfo: true
-    config-opts:
-      - -DGSTREAMER=ON
-    sources:
-      - type: archive
-        url: https://github.com/FNA-XNA/FAudio/archive/20.12.tar.gz
-        sha256: d5a1656ec79cd2878dddabc07d7f7848c11844595c76033aed929b10d922c009
-
-  - name: faudio64
-    buildsystem: cmake-ninja
-    build-options:
-      prefix: /app/wine
-      libdir: /app/wine/lib
-      strip: true
-      no-debuginfo: true
-    config-opts:
-      - -DGSTREAMER=ON
-    sources:
-      - type: archive
-        url: https://github.com/FNA-XNA/FAudio/archive/20.12.tar.gz
-        sha256: d5a1656ec79cd2878dddabc07d7f7848c11844595c76033aed929b10d922c009
-
   - name: wine
     build-options:
       config-opts:
         - --enable-win64
       libdir: /app/wine/lib
-      ldflags: -L/app/wine/lib
     config-opts: &wine-config-opts
       - --disable-win16
       - --without-ldap
@@ -98,7 +63,7 @@ modules:
   - name: wine-32bit
     build-options:
       libdir: /app/wine/lib32
-      ldflags: -L/app/wine/lib32 -L/app/lib32 -Wl,-z,relro,-z,now -Wl,--as-needed
+      ldflags: -L/app/lib32 -Wl,-z,relro,-z,now -Wl,--as-needed
       ldflags-override: true
       env:
         CC: i686-unknown-linux-gnu-gcc


### PR DESCRIPTION
FAudio is currently build as part of the com.fightcade.Fightcade
runtime. Work is being done on bringing it into this extension, but for
now we should build against that on the stable branch.

This reverts commit aa6aa100b994c47ee8fb32d499cdb0d0ce1bb86c.